### PR TITLE
Language field name changed from text -> textContent

### DIFF
--- a/src/ggg/ggg.js
+++ b/src/ggg/ggg.js
@@ -31,7 +31,7 @@ function ggg() {
     if ($("div.btn.btn-sm.ggg-btn").length > 0) return;
 
     $("span[itemprop='keywords'].language-color").each(function () {
-        if ($(this).text() !== 'Go') return;
+        if ($(this).textContent() !== 'Go') return;
 
         $("div.select-menu-modal-holder.dropdown-menu-content.js-menu-content")
             .after("<div class='btn btn-sm ggg-btn'><div class='ggg-gopher'></div></div>");


### PR DESCRIPTION
Noticed that the gopher button wasn't appearing, and it appears that Github may have changed the name of the field that stored the language name. 

I have tested that this correctly matches Go projects and doesn't match non-Go projects via the Chrome console, but not as a packaged Chrome extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dlsniper/ggg/4)
<!-- Reviewable:end -->
